### PR TITLE
fix: provide possibility to define common rc files #UTCORE-121

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,8 @@ function mount(parent, m) {
     }
 }
 
+const getRcName = (name, env) => `ut_${name.replace(/[-/\\]/g, '_')}_${env}`;
+
 function load({ params, app, method, env, root, version, resolve, config, context, defaultConfig, defaultOverlays } = {}) {
     const argv = merge([{}, require('minimist')(process.argv.slice(2))], {convert: true});
     const baseConfig = {
@@ -107,11 +109,12 @@ function load({ params, app, method, env, root, version, resolve, config, contex
         };
     }));
 
-    if (!appname) {
-        baseConfig.params.appname = appname = `ut_${implementation.replace(/[-/\\]/g, '_')}_${baseConfig.params.env}`;
-    }
+    if (!appname) baseConfig.params.appname = appname = getRcName(implementation, baseConfig.params.env);
 
-    configs.push(rc(appname, {}, argv, parse));
+    configs.push(
+        rc(appname, {}, argv, parse),
+        ...[].concat(defaultOverlays).filter(Boolean).map(overlay => rc(getRcName(overlay, baseConfig.params.env), {}, argv, parse))
+    );
 
     configs.unshift(baseConfig);
 

--- a/index.js
+++ b/index.js
@@ -57,8 +57,6 @@ function mount(parent, m) {
     }
 }
 
-const getRcName = (name, env) => `ut_${name.replace(/[-/\\]/g, '_')}_${env}`;
-
 function load({ params, app, method, env, root, version, resolve, config, context, defaultConfig, defaultOverlays } = {}) {
     const argv = merge([{}, require('minimist')(process.argv.slice(2))], {convert: true});
     const baseConfig = {
@@ -109,12 +107,12 @@ function load({ params, app, method, env, root, version, resolve, config, contex
         };
     }));
 
-    if (!appname) baseConfig.params.appname = appname = getRcName(implementation, baseConfig.params.env);
+    if (!appname) {
+        baseConfig.params.appname = appname = `ut_${implementation.replace(/[-/\\]/g, '_')}_${baseConfig.params.env}`;
+    }
 
-    configs.push(
-        rc(appname, {}, argv, parse),
-        ...[].concat(defaultOverlays).filter(Boolean).map(overlay => rc(getRcName(overlay, baseConfig.params.env), {}, argv, parse))
-    );
+    configs.push(rc(appname, {}, argv, parse));
+    configs.push(rc(`ut_${baseConfig.params.env}`, {}, argv, parse));
 
     configs.unshift(baseConfig);
 


### PR DESCRIPTION
E.g. put an rc in home directory which loads for all microservices/implementations

.ut_devrc

```yaml
db:
  connection:
    user: aaa
    password: bbb
  create:
    user: ccc
    password: ddd
```